### PR TITLE
Update streamlit app deployment

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import streamlit as st
 import os
 
+# Version: 1.0.1 - Fixed requirements.txt issue
 st.set_page_config(
     page_title="Fenestration Pro AI",
     page_icon="🏗️",

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,6 @@ altair==5.0.1
 
 # Database and Storage
 sqlalchemy==2.0.21
-sqlite3
 redis==5.0.0
 boto3==1.34.144
 


### PR DESCRIPTION
Remove `sqlite3` from `requirements.txt` and update `app.py` to fix Streamlit deployment issues.

The `sqlite3` entry in `requirements.txt` was causing Streamlit deployments to fail because `sqlite3` is a standard Python library module and not a package installable via pip. Removing it resolves this deployment blocker, and the `app.py` change triggers a new deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-808bda11-434a-4712-ae4e-343067006d71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-808bda11-434a-4712-ae4e-343067006d71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

