### PR TITLE
Restart the application

### DIFF
--- a/.ps.txt
+++ b/.ps.txt
@@ -1,0 +1,5 @@
+UID          PID    PPID  C STIME TTY          TIME CMD
+root           1       0  0 16:30 ?        00:00:00 /pod-daemon
+ubuntu       322       1  0 21:25 ?        00:00:01 /exec-daemon/node /exec-daemon/index.js
+ubuntu       905     322 25 21:27 ?        00:00:00 /bin/bash -O extglob -c snap=$(command cat <&3) && builtin shopt -s extglob && builtin eval -- "$snap" && { builtin export PWD="$(builtin pwd)"; builtin eval "$1" < /dev/null; }; COMMAND_EXIT_CODE=$?; dump_bash_state >&4; builtin exit $COMMAND_EXIT_CODE -- ps -ef > "/workspace/.ps.txt"
+ubuntu       917     905  0 21:27 ?        00:00:00 ps -ef


### PR DESCRIPTION
Add `.ps.txt` to record process state during app restart attempt.

This file was generated as part of the diagnostic process to identify running application instances before attempting to restart the app, as no existing app processes were found.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9c01e0e-e696-4649-aca0-98ffc9cd5b2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d9c01e0e-e696-4649-aca0-98ffc9cd5b2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

